### PR TITLE
Update lti-tool-learndash.php

### DIFF
--- a/lti-tool-learndash.php
+++ b/lti-tool-learndash.php
@@ -527,6 +527,7 @@ function lti_tool_learndash_update_activity($args)
                 reset($usermeta['lti_tool_user_id']), $lti_tool_learndash_score);
         }
     }
+    return $args;
 }
 
 add_filter('learndash_update_user_activity_args', 'lti_tool_learndash_update_activity', 10, 1);


### PR DESCRIPTION
When plugin is active LearnDash stops recording data to the learndash_user_activity table. Found issue was in the lti_tool_learndash_update_activity function fixed by adding return with args to function. This allows LearnDash activity to be saved both to the local site and be pushed to LTi with no issues.